### PR TITLE
Closes #1 - Support strings in findRenamed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/build/bin.d.ts
+++ b/build/bin.d.ts
@@ -1,2 +1,31 @@
 #!/usr/bin/env node
-export {};
+/**
+ * Configuration file for travis-size-report.
+ * This is typically `sizereport.config.js`.
+ */
+export interface Config {
+    /**
+     * The username/repo-name
+     * @example
+     * repo: "GoogleChromeLabs/travis-size-report"
+     */
+    repo: string;
+    /**
+     * The glob (or array of globs) of files to include in the report.
+     * @example
+     * path: 'dist/*'
+     */
+    path: string | readonly string[];
+    /**
+     * The branch to check against.
+     * @default 'master'
+     * @example
+     * branch: 'develop'
+     */
+    branch?: string;
+    /**
+     * By default, a renamed file will look like one file deleted and another created.
+     * By writing a findRenamed callback, you can tell travis-size-report that a file was renamed.
+     */
+    findRenamed?: string | import('./find-renamed').FindRenamed;
+}

--- a/build/bin.js
+++ b/build/bin.js
@@ -11,14 +11,17 @@ const argv = minimist_1.default(process.argv.slice(2), {
     string: ['branch'],
     alias: { c: 'config' },
 });
+// Read arguments from command line
 const branch = argv.branch;
 const configFile = argv.config;
 const repo = argv._[0];
 const glob = argv._[1];
 let config = {};
+// Read arguments from config file
 if (configFile) {
     config = require(path_1.default.join(process.cwd(), configFile === true ? 'sizereport.config.js' : configFile));
 }
+// Override config file with command line arguments
 if (repo)
     config.repo = repo;
 if (glob)

--- a/build/find-renamed.d.ts
+++ b/build/find-renamed.d.ts
@@ -1,0 +1,14 @@
+export declare type FindRenamed = (
+/** Path of a file that's missing in the latest build */
+filePath: string, 
+/** Paths of files that are new in the latest build */
+newFiles: string[]) => string | undefined | PromiseLike<string | undefined>;
+/**
+ * Creates a findRenamed function based on the given `pattern`.
+ *
+ * Patterns support the following placeholders:
+ * - `[extname]`: The file extension of the asset including a leading dot, e.g. `.css`
+ * - `[hash]`: A hash based on the name and content of the asset.
+ * - `[name]`: The file name of the asset excluding any extension.
+ */
+export declare function buildFindRenamedFunc(pattern: string): FindRenamed;

--- a/build/find-renamed.js
+++ b/build/find-renamed.js
@@ -1,0 +1,62 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const escape_string_regexp_1 = __importDefault(require("escape-string-regexp"));
+const PLACEHOLDER_REGEX = /\\\[(\w+)\\\]/g;
+const REPLACEMENTS = {
+    extname: '(\\.\\w+)',
+    hash: '[a-f0-9]+',
+    name: '(.+)',
+};
+/**
+ * Name doesn't start with "./", "/", "../"
+ */
+function isPlainName(name) {
+    return !(name[0] === '/' ||
+        (name[1] === '.' && (name[2] === '/' || (name[2] === '.' && name[3] === '/'))));
+}
+/**
+ * Creates a findRenamed function based on the given `pattern`.
+ *
+ * Patterns support the following placeholders:
+ * - `[extname]`: The file extension of the asset including a leading dot, e.g. `.css`
+ * - `[hash]`: A hash based on the name and content of the asset.
+ * - `[name]`: The file name of the asset excluding any extension.
+ */
+function buildFindRenamedFunc(pattern) {
+    if (!isPlainName(pattern)) {
+        throw new TypeError(`Invalid output pattern "${pattern}, cannot be an absolute or relative path.`);
+    }
+    // Keep track of which placeholder each regex group corresponds to.
+    let i = 1;
+    const groups = [];
+    // Create a regex to extract parts of the path.
+    const parts = escape_string_regexp_1.default(pattern).replace(PLACEHOLDER_REGEX, (_match, type) => {
+        const replacement = REPLACEMENTS[type];
+        if (replacement == undefined) {
+            throw new TypeError(`"${type}" is not a valid substitution name`);
+        }
+        groups[i] = type;
+        i++;
+        return replacement;
+    });
+    const partsRe = new RegExp(`^${parts}$`);
+    return function generatedFindRenamed(path, newPaths) {
+        const oldParts = partsRe.exec(path);
+        if (!oldParts)
+            return undefined;
+        return newPaths.find(newPath => {
+            const newParts = partsRe.exec(newPath);
+            if (!newParts || newParts.length !== oldParts.length)
+                return false;
+            for (let i = 1; i < oldParts.length; i++) {
+                if (oldParts[i] !== newParts[i] && groups[i] !== 'hash')
+                    return false;
+            }
+            return true;
+        });
+    };
+}
+exports.buildFindRenamedFunc = buildFindRenamedFunc;

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,8 +1,3 @@
-export declare type FindRenamed = (
-/** Path of a file that's missing in the latest build */
-filePath: string, 
-/** Paths of files that are new in the latest build */
-newFiles: string[]) => string | void | Promise<void> | Promise<string>;
 export interface SizeReportOptions {
     /** Branch to compare to. Defaults to 'master' */
     branch?: string;
@@ -15,6 +10,6 @@ export interface SizeReportOptions {
      *
      * This can be async, returning a promise for a string or undefined.
      */
-    findRenamed?: FindRenamed;
+    findRenamed?: string | import('./find-renamed').FindRenamed;
 }
-export default function sizeReport(user: string, repo: string, files: string | string[], { branch, findRenamed }?: SizeReportOptions): Promise<void>;
+export default function sizeReport(user: string, repo: string, files: string | readonly string[], { branch, findRenamed }?: SizeReportOptions): Promise<void>;

--- a/build/index.js
+++ b/build/index.js
@@ -12,6 +12,7 @@ const escape_string_regexp_1 = __importDefault(require("escape-string-regexp"));
 const node_fetch_1 = __importDefault(require("node-fetch"));
 const chalk_1 = __importDefault(require("chalk"));
 const pretty_bytes_1 = __importDefault(require("pretty-bytes"));
+const find_renamed_1 = require("./find-renamed");
 const globP = util_1.promisify(glob_1.default);
 const statP = util_1.promisify(fs_1.stat);
 // Travis reports it doesn't support colour. IT IS WRONG.
@@ -154,6 +155,8 @@ function outputChanges(changes) {
 async function sizeReport(user, repo, files, { branch = 'master', findRenamed } = {}) {
     if (typeof files === 'string')
         files = [files];
+    if (typeof findRenamed === 'string')
+        findRenamed = find_renamed_1.buildFindRenamedFunc(findRenamed);
     // Get target files
     const filePaths = [];
     for (const glob of files) {

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
     "husky": "^1.3.1",
     "prettier": "^1.17.0",
     "pretty-quick": "^1.10.0"
-  }
+  },
+  "files": [
+    "build",
+    "README.md"
+  ]
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,27 +1,53 @@
 #!/usr/bin/env node
 import path from 'path';
 import minimist from 'minimist';
-import sizeReport from '.';
+import sizeReport, { SizeReportOptions } from '.';
 
 const argv = minimist(process.argv.slice(2), {
   string: ['branch'],
   alias: { c: 'config' },
 });
 
+// Read arguments from command line
 const branch = argv.branch as string;
 const configFile = argv.config as string | boolean;
 const repo = argv._[0] as string | undefined;
 const glob = argv._[1] as string | undefined;
 
-interface Config {
-  repo?: string;
-  path?: string;
+/**
+ * Configuration file for travis-size-report.
+ * This is typically `sizereport.config.js`.
+ */
+export interface Config {
+  /**
+   * The username/repo-name
+   * @example
+   * repo: "GoogleChromeLabs/travis-size-report"
+   */
+  repo: string;
+  /**
+   * The glob (or array of globs) of files to include in the report.
+   * @example
+   * path: 'dist/*'
+   */
+  path: string | readonly string[];
+  /**
+   * The branch to check against.
+   * @default 'master'
+   * @example
+   * branch: 'develop'
+   */
   branch?: string;
-  findRenamed?: import('.').FindRenamed;
+  /**
+   * By default, a renamed file will look like one file deleted and another created.
+   * By writing a findRenamed callback, you can tell travis-size-report that a file was renamed.
+   */
+  findRenamed?: string | import('./find-renamed').FindRenamed;
 }
 
-let config: Config = {};
+let config: Partial<Config> = {};
 
+// Read arguments from config file
 if (configFile) {
   config = require(path.join(
     process.cwd(),
@@ -29,6 +55,7 @@ if (configFile) {
   ));
 }
 
+// Override config file with command line arguments
 if (repo) config.repo = repo;
 if (glob) config.path = glob;
 if (branch) config.branch = branch;
@@ -38,7 +65,7 @@ if (!config.path) throw TypeError('No path given');
 if (!config.repo.includes('/')) throw TypeError("Repo doesn't look like repo value");
 
 const [user, repoName] = config.repo.split('/');
-const opts: import('.').SizeReportOptions = {};
+const opts: SizeReportOptions = {};
 if (config.branch) opts.branch = config.branch;
 if (config.findRenamed) opts.findRenamed = config.findRenamed;
 

--- a/src/find-renamed.ts
+++ b/src/find-renamed.ts
@@ -1,0 +1,72 @@
+import escapeRE from 'escape-string-regexp';
+
+export type FindRenamed = (
+  /** Path of a file that's missing in the latest build */
+  filePath: string,
+  /** Paths of files that are new in the latest build */
+  newFiles: string[],
+) => string | undefined | PromiseLike<string | undefined>;
+
+const PLACEHOLDER_REGEX = /\\\[(\w+)\\\]/g;
+const REPLACEMENTS = {
+  extname: '(\\.\\w+)',
+  hash: '[a-f0-9]+',
+  name: '(.+)',
+};
+type Placeholder = keyof typeof REPLACEMENTS;
+
+/**
+ * Name doesn't start with "./", "/", "../"
+ */
+function isPlainName(name: string) {
+  return !(
+    name[0] === '/' ||
+    (name[1] === '.' && (name[2] === '/' || (name[2] === '.' && name[3] === '/')))
+  );
+}
+
+/**
+ * Creates a findRenamed function based on the given `pattern`.
+ *
+ * Patterns support the following placeholders:
+ * - `[extname]`: The file extension of the asset including a leading dot, e.g. `.css`
+ * - `[hash]`: A hash based on the name and content of the asset.
+ * - `[name]`: The file name of the asset excluding any extension.
+ */
+export function buildFindRenamedFunc(pattern: string): FindRenamed {
+  if (!isPlainName(pattern)) {
+    throw new TypeError(
+      `Invalid output pattern "${pattern}, cannot be an absolute or relative path.`,
+    );
+  }
+
+  // Keep track of which placeholder each regex group corresponds to.
+  let i = 1;
+  const groups: Placeholder[] = [];
+
+  // Create a regex to extract parts of the path.
+  const parts = escapeRE(pattern).replace(PLACEHOLDER_REGEX, (_match, type) => {
+    const replacement = REPLACEMENTS[type as Placeholder];
+    if (replacement == undefined) {
+      throw new TypeError(`"${type}" is not a valid substitution name`);
+    }
+    groups[i] = type;
+    i++;
+    return replacement;
+  });
+  const partsRe = new RegExp(`^${parts}$`);
+
+  return function generatedFindRenamed(path, newPaths) {
+    const oldParts = partsRe.exec(path);
+    if (!oldParts) return undefined;
+
+    return newPaths.find(newPath => {
+      const newParts = partsRe.exec(newPath);
+      if (!newParts || newParts.length !== oldParts.length) return false;
+      for (let i = 1; i < oldParts.length; i++) {
+        if (oldParts[i] !== newParts[i] && groups[i] !== 'hash') return false;
+      }
+      return true;
+    });
+  };
+}


### PR DESCRIPTION
Adds support for `{ findRenamed: '[name]-[hash].js' }`! A lot of the code is borrowed from rollup and Squoosh. 

`Config` is also now exported, so `sizereport.config.js` can be typechecked.

I can write tests for the new code, but I want to know which testing framework you'd prefer first.